### PR TITLE
feat: Allows `/* SQL */ ""` pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-inline-sql",
   "displayName": "Inline SQL",
   "description": "Syntax highlighting for sql in template literals",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "jtladeiras",
   "license": "MIT",
   "repository": {

--- a/syntaxes/lit-sql.json
+++ b/syntaxes/lit-sql.json
@@ -1,40 +1,40 @@
 {
-	"fileTypes": [],
-	"injectionSelector": "L:source -comment -string",
-	"patterns": [
-		{
-			"name": "taggedTemplates",
-			"contentName": "meta.embedded.block.sql",
-			"begin": "(?x)(\\s*?(\\w+\\.)?(?:(sql|SQL)|/\\*\\s*(sql|SQL)\\s*\\*/)\\s*)(`|'|\")",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.tagged-template.js"
-				},
-				"2": {
-					"name": "string.js"
-				},
-				"3": {
-					"name": "punctuation.definition.string.template.begin.js"
-				}
-			},
-			"end": "(`|'|\")",
-			"endCaptures": {
-				"0": {
-					"name": "string.js"
-				},
-				"1": {
-					"name": "punctuation.definition.string.template.end.js"
-				}
-			},
-			"patterns": [
-				{
-					"include": "source.ts#template-substitution-element"
-				},
-				{
-					"include": "source.sql"
-				}
-			]
-		}
-	],
-	"scopeName": "inline.lit-sql"
+  "fileTypes": [],
+  "injectionSelector": "L:source -comment -string",
+  "patterns": [
+    {
+      "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.sql",
+      "begin": "(?x)(\\s*?(\\w+\\.)?(?:(sql|SQL)|/\\*\\s*(sql|SQL)\\s*\\*/)\\s*)(`|'|\")",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "2": {
+          "name": "string.js"
+        },
+        "3": {
+          "name": "punctuation.definition.string.template.begin.js"
+        }
+      },
+      "end": "(`|'|\")",
+      "endCaptures": {
+        "0": {
+          "name": "string.js"
+        },
+        "1": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.sql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.lit-sql"
 }

--- a/syntaxes/lit-sql.json
+++ b/syntaxes/lit-sql.json
@@ -1,40 +1,40 @@
 {
-  "fileTypes": [],
-  "injectionSelector": "L:source -comment -string",
-  "patterns": [
-    {
-      "name": "taggedTemplates",
-      "contentName": "meta.embedded.block.sql",
-      "begin": "(?x)(\\s*?(\\w+\\.)?(?:sql|/\\*\\s*sql\\s*\\*/)\\s*)(`)",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name.function.tagged-template.js"
-        },
-        "2": {
-          "name": "string.js"
-        },
-        "3": {
-          "name": "punctuation.definition.string.template.begin.js"
-        }
-      },
-      "end": "(`)",
-      "endCaptures": {
-        "0": {
-          "name": "string.js"
-        },
-        "1": {
-          "name": "punctuation.definition.string.template.end.js"
-        }
-      },
-      "patterns": [
-        {
-          "include": "source.ts#template-substitution-element"
-        },
-        {
-          "include": "source.sql"
-        }
-      ]
-    }
-  ],
-  "scopeName": "inline.lit-sql"
+	"fileTypes": [],
+	"injectionSelector": "L:source -comment -string",
+	"patterns": [
+		{
+			"name": "taggedTemplates",
+			"contentName": "meta.embedded.block.sql",
+			"begin": "(?x)(\\s*?(\\w+\\.)?(?:(sql|SQL)|/\\*\\s*(sql|SQL)\\s*\\*/)\\s*)(`|'|\")",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.tagged-template.js"
+				},
+				"2": {
+					"name": "string.js"
+				},
+				"3": {
+					"name": "punctuation.definition.string.template.begin.js"
+				}
+			},
+			"end": "(`|'|\")",
+			"endCaptures": {
+				"0": {
+					"name": "string.js"
+				},
+				"1": {
+					"name": "punctuation.definition.string.template.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "source.ts#template-substitution-element"
+				},
+				{
+					"include": "source.sql"
+				}
+			]
+		}
+	],
+	"scopeName": "inline.lit-sql"
 }


### PR DESCRIPTION
This PR allows a pattern such as 
```
/* SQL */ "SELECT..."
```

The motivation behind it is prettier substitutes the backtick with a regular quotes pretty often, and the syntax highlight stops working.

The uppercase pattern also matches the `/* HTML */` and `/* GraphQL */` highlighters better.