### PR TITLE
fix: allow type parameters, tagged template literals that end with Sql

### DIFF
--- a/syntaxes/lit-sql.json
+++ b/syntaxes/lit-sql.json
@@ -5,7 +5,7 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.sql",
-      "begin": "(?x)(\\s*?(\\w+\\.)?(?:(sql|SQL)|/\\*\\s*(sql|SQL)\\s*\\*/)\\s*)(`)",
+      "begin": "(?x)(\\s*?(\\w+\\.)?\\w*(?:(sql|SQL|Sql)(\\<\\w+\\>)?|/\\*\\s*(sql|SQL|Sql)\\s*\\*/)\\s*)(`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tagged-template.js"

--- a/syntaxes/lit-sql.json
+++ b/syntaxes/lit-sql.json
@@ -5,7 +5,7 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.sql",
-      "begin": "(?x)(\\s*?(\\w+\\.)?\\w*(?:(sql|SQL|Sql)(\\<\\w+\\>)?|/\\*\\s*(sql|SQL|Sql)\\s*\\*/)\\s*)(`)",
+      "begin": "(?x)(\\s*?(\\w+\\.)?\\w*(?:(sql|SQL|Sql)(\\<[^>]+\\>)?|/\\*\\s*(sql|SQL|Sql)\\s*\\*/)\\s*)(`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.tagged-template.js"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const user = 'user';
 
 const query = /* sql */`
-  SELECT * 
+  SELECT *
   FROM "${user}" u
 `;
 

--- a/test.ts
+++ b/test.ts
@@ -6,3 +6,5 @@ interface User {
 let roSql: any;
 
 const resultPromise = roSql<User>`SELECT * FROM users`;
+
+const otherResultPromise = roSql<{ id: number }>`SELECT id FROM users`;

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,8 @@
+interface User {
+    id: number;
+    name: string;
+}
+
+let roSql: any;
+
+const resultPromise = roSql<User>`SELECT * FROM users`;


### PR DESCRIPTION
1. allow type parameters
    I did this a bit naively, ie don't allow nested types like sql<ModifyType<SomeType<SomeInterface>>>, I figured some support is better than nothing
2. variously named tagged template literals
    We have read-only instances that have their own tagged template literals and they're named something like rosql